### PR TITLE
Move spinner tokens from foundations to component

### DIFF
--- a/src/Spinner/Tokens/tokens.ts
+++ b/src/Spinner/Tokens/tokens.ts
@@ -1,0 +1,150 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  primary: {
+    solid: {
+      spin: {
+        color: inube.palette.blue.B400,
+      },
+      track: {
+        color: inube.palette.neutral.N30,
+      },
+    },
+    transparent: {
+      spin: {
+        color: inube.palette.blue.B400,
+      },
+      track: {
+        color: inube.palette.neutralAlpha.N0A,
+      },
+    },
+  },
+  success: {
+    solid: {
+      spin: {
+        color: inube.palette.green.G400,
+      },
+      track: {
+        color: inube.palette.neutral.N30,
+      },
+    },
+    transparent: {
+      spin: {
+        color: inube.palette.green.G400,
+      },
+      track: {
+        color: inube.palette.neutralAlpha.N0A,
+      },
+    },
+  },
+  warning: {
+    solid: {
+      spin: {
+        color: inube.palette.yellow.Y400,
+      },
+      track: {
+        color: inube.palette.neutral.N30,
+      },
+    },
+    transparent: {
+      spin: {
+        color: inube.palette.yellow.Y400,
+      },
+      track: {
+        color: inube.palette.neutralAlpha.N0A,
+      },
+    },
+  },
+  danger: {
+    solid: {
+      spin: {
+        color: inube.palette.red.R400,
+      },
+      track: {
+        color: inube.palette.neutral.N30,
+      },
+    },
+    transparent: {
+      spin: {
+        color: inube.palette.red.R400,
+      },
+      track: {
+        color: inube.palette.neutralAlpha.N0A,
+      },
+    },
+  },
+  help: {
+    solid: {
+      spin: {
+        color: inube.palette.purple.P400,
+      },
+      track: {
+        color: inube.palette.neutral.N30,
+      },
+    },
+    transparent: {
+      spin: {
+        color: inube.palette.purple.P400,
+      },
+      track: {
+        color: inube.palette.neutralAlpha.N0A,
+      },
+    },
+  },
+  dark: {
+    solid: {
+      spin: {
+        color: inube.palette.neutral.N900,
+      },
+      track: {
+        color: inube.palette.neutral.N30,
+      },
+    },
+    transparent: {
+      spin: {
+        color: inube.palette.neutral.N900,
+      },
+      track: {
+        color: inube.palette.neutralAlpha.N0A,
+      },
+    },
+  },
+  gray: {
+    solid: {
+      spin: {
+        color: inube.palette.neutral.N100,
+      },
+      track: {
+        color: inube.palette.neutral.N30,
+      },
+    },
+    transparent: {
+      spin: {
+        color: inube.palette.neutral.N100,
+      },
+      track: {
+        color: inube.palette.neutralAlpha.N0A,
+      },
+    },
+  },
+  light: {
+    solid: {
+      spin: {
+        color: inube.palette.neutral.N10,
+      },
+      track: {
+        color: inube.palette.neutral.N30,
+      },
+    },
+    transparent: {
+      spin: {
+        color: inube.palette.neutral.N10,
+      },
+      track: {
+        color: inube.palette.neutralAlpha.N0A,
+      },
+    },
+  },
+};
+
+export { tokens };

--- a/src/Spinner/styles.js
+++ b/src/Spinner/styles.js
@@ -1,5 +1,5 @@
 import styled, { keyframes } from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const sizes = {
   large: {
@@ -32,15 +32,15 @@ const StyledSpinner = styled.div`
   border-color: ${({ theme, $transparent, $appearance }) =>
     $transparent === true
       ? theme?.spinner?.[$appearance]?.transparent?.track?.color ||
-        inube.spinner[$appearance].transparent.track.color
+        tokens[$appearance].transparent.track.color
       : theme?.spinner?.[$appearance]?.solid?.track?.color ||
-        inube.spinner[$appearance].solid.track.color};
+        tokens[$appearance].solid.track.color};
   border-bottom-color: ${({ $appearance, $transparent, theme }) =>
     $transparent === true
       ? theme?.spinner?.[$appearance]?.transparent?.spin?.color ||
-        inube?.spinner[$appearance].transparent?.spin?.color
+        tokens[$appearance].transparent?.spin?.color
       : theme?.spinner?.[$appearance]?.solid?.spin?.color ||
-        inube?.spinner[$appearance].solid?.spin?.color};
+        tokens[$appearance].solid?.spin?.color};
   border-radius: 50%;
   ${({ $size }) => $size && sizes[$size]}
   box-sizing: border-box;


### PR DESCRIPTION
This PR relocates the spinner tokens from the foundations folder to the component folder, updating all necessary imports to align with the new structure and ensuring components reference the correct token paths. This update improves the organization, maintainability, and clarity of the codebase.